### PR TITLE
adding default timeout for socket. That stops connections to hang forever

### DIFF
--- a/smtp-gee.py
+++ b/smtp-gee.py
@@ -18,6 +18,8 @@ import sys
 from email.mime.text import MIMEText
 from email.parser import Parser
 
+socket.setdefaulttimeout(10)
+
 
 class Account(object): # {{{
     """docstring for Account"""


### PR DESCRIPTION
Just a default timeout for sockets in use...
No socket connect should take longer than 10 seconds.
